### PR TITLE
Hotfix: Remoção do script de build no package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "start": "babel-node ./bin/www.js",
     "dev": "cross-env DEBUG=app nodemon --exec babel-node ./bin/www",
-    "build": "babel . --ignore node_modules -d lib",
     "format": "prettier --write \"./**/*.js\""
   },
   "dependencies": {


### PR DESCRIPTION
- [x] Remoção do script de build na package.json

Durante o deploy para a heroku, houve erro na hora de buildar porque o arquivo package.json possuía um comand de build que resultado em erro no ambiente de produção e conflitava com o build do próprio heroku. 
