### PR TITLE
Feature Users and boards

### DIFF
--- a/prisma/migrations/20211202051850_virtual_boards_pk/migration.sql
+++ b/prisma/migrations/20211202051850_virtual_boards_pk/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - The primary key for the `virtual_boards` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - You are about to drop the column `id` on the `virtual_boards` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "virtual_boards" DROP CONSTRAINT "virtual_boards_pkey",
+DROP COLUMN "id",
+ADD CONSTRAINT "virtual_boards_pkey" PRIMARY KEY ("userId", "boardId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -62,9 +62,6 @@ model Manager {
 }
 
 model UsersOnBoards {
-  // fields
-  id String @id @default(uuid())
-
   // relations
   Board   Board  @relation(fields: [boardId], references: [id])
   User    User   @relation(fields: [userId], references: [id])
@@ -74,6 +71,7 @@ model UsersOnBoards {
   // timestamps
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+  @@id([userId, boardId])
   @@map("virtual_boards")
 }
 

--- a/src/controllers/boards/index.js
+++ b/src/controllers/boards/index.js
@@ -1,6 +1,7 @@
 export const NewBoardController = (serviceContainer) => {
   const boardService = serviceContainer.BoardService;
   const managerService = serviceContainer.ManagerService;
+  const userService = serviceContainer.UserService;
 
   const create = async (body, userId) => {
     let { errors, ok } = await boardService.create(body);
@@ -32,5 +33,17 @@ export const NewBoardController = (serviceContainer) => {
     return { ok: await boardService.getBoard(boardId) };
   };
 
-  return { create, deleteBoard, getBoard };
+  const addUser = async (boardId, userId, managerId) => {
+    if (!(await boardService.exists(boardId)))
+      return { errors: "board.not-found" };
+    if (!(await managerService.isManagerOfBoard(boardId, managerId)))
+      return { errors: "operaiton.forbidden" };
+    const orgId = await boardService.getOrganization(boardId);
+    const userOrgId = await userService.getOrganization(userId);
+
+    if (orgId != userOrgId) return { errors: "operation.forbidden" };
+    return { ok: await boardService.addUser(boardId, userId) };
+  };
+
+  return { create, deleteBoard, getBoard, addUser };
 };

--- a/src/repositories/boards/index.js
+++ b/src/repositories/boards/index.js
@@ -104,6 +104,17 @@ export const NewBoardRepository = (database) => {
     return board;
   };
 
+  const getOrganization = async (boardId) => {
+    const result = await db.$queryRaw`
+      SELECT o.id
+      FROM virtual_boards vb
+      JOIN users u ON vb."userId" = u.id 
+      JOIN organizations o ON u."organizationId" = o.id
+      WHERE vb."boardId" = ${boardId}
+    `;
+    return result[0].id;
+  };
+
   return {
     addUser,
     create,
@@ -112,5 +123,6 @@ export const NewBoardRepository = (database) => {
     exists,
     containsUser,
     getBoard,
+    getOrganization,
   };
 };

--- a/src/repositories/users/index.js
+++ b/src/repositories/users/index.js
@@ -58,6 +58,16 @@ export const NewUserRepository = (database) => {
     });
   };
 
+  const getOrganization = async (userId) => {
+    const result = await db.$queryRaw`
+    SELECT o.id
+    FROM users u
+    JOIN organizations o ON u."organizationId" = o.id
+    WHERE u.id = ${userId}
+    `;
+    return result[0].id;
+  };
+
   return {
     isEmailUnique,
     isUsernameUnique,
@@ -65,5 +75,6 @@ export const NewUserRepository = (database) => {
     signinWithEmail,
     signinWithUsername,
     updateUser,
+    getOrganization,
   };
 };

--- a/src/routers/boards.js
+++ b/src/routers/boards.js
@@ -50,11 +50,32 @@ const BoardRouter = (
     if (ok) return res.status(200).json({ data: ok });
     if (errors) {
       if (errors.includes("not-found"))
-        return res.status(404).json({ data: ok });
+        return res.status(404).json({ data: errors });
       if (errors == "operation.forbidden")
         return res.status(403).json({ errors: errors });
-      return res.status(400).json({ errors: errors });
     }
+    return res.status(400).json({ errors: errors });
+  });
+
+  // User related
+  router.post("/:board_id/user/:user_id", async (req, res) => {
+    const managerId = res.locals.user.id;
+    const boardId = req.params.board_id;
+    const userId = req.params.user_id;
+
+    const { ok, errors } = await boardController.addUser(
+      boardId,
+      userId,
+      managerId
+    );
+    if (ok) return res.status(200).json({ data: ok });
+    if (errors) {
+      if (errors.includes("not-found"))
+        return res.status(404).json({ errors: errors });
+      if (errors == "operation.forbidden")
+        return res.status(403).json({ errors: errors });
+    }
+    return res.status(400).json({ errors: errors });
   });
 
   // Lists

--- a/src/services/boards/index.js
+++ b/src/services/boards/index.js
@@ -50,6 +50,10 @@ export const NewBoardService = (repositoryContainer) => {
     return await repo.getBoard(boardId);
   };
 
+  const getOrganization = async (boardId) => {
+    return await repo.getOrganization(boardId);
+  };
+
   return {
     addUser,
     create,
@@ -59,5 +63,6 @@ export const NewBoardService = (repositoryContainer) => {
     exists,
     containsUser,
     getBoard,
+    getOrganization,
   };
 };

--- a/src/services/users/index.js
+++ b/src/services/users/index.js
@@ -157,5 +157,9 @@ export const NewUserService = (repositoryContainer, jwt, passwordHasher) => {
     return { ok: updatedUser };
   };
 
-  return { isSignupValid, signup, signin, update };
+  const getOrganization = async (userId) => {
+    return await repo.getOrganization(userId);
+  };
+
+  return { isSignupValid, signup, signin, update, getOrganization };
 };


### PR DESCRIPTION
# Motivação
Adição de usuários ao board. Como no DB essa ação é feita através de uma tabela intermediária pra relacionar usuários e boards `virtual_boards`, foi necessário trocar a private key dessa tabela para que usasse o par user.id, board.id como pk.

# Mudanças
## Adições
- [x] Verificação de que o o board e novo usuário pertencem a mesma organização
- [x] Rota para adicionar usuário ao board
- [ ] Rota para remover usuário do board
- [ ] Rota para sair do board

## Alterações
- [x] Private key da tabela intermediária `virtual_boards`